### PR TITLE
Fix for linefeed issues in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 apidocs
 testdocs
+tests/cases/output
+tests/cases/tmp
+doclets/standard/geshi
+*.komodoproject
+*.komodotools

--- a/classes/phpDoctor.php
+++ b/classes/phpDoctor.php
@@ -546,6 +546,8 @@ class PHPDoctor
                     $this->message('Reading file "'.$filename.'"');
                     $fileString = @file_get_contents($filename);
                     if ($fileString !== FALSE) {
+						$fileString = str_replace( "\r\n", "\n", $fileString ); // fix Windows line endings
+						
                         $this->_currentFilename = $filename;
                         
                         $tokens = token_get_all($fileString);

--- a/classes/phpDoctor.php
+++ b/classes/phpDoctor.php
@@ -547,6 +547,7 @@ class PHPDoctor
                     $fileString = @file_get_contents($filename);
                     if ($fileString !== FALSE) {
 						$fileString = str_replace( "\r\n", "\n", $fileString ); // fix Windows line endings
+						$fileString = str_replace( "\r", "\n", $fileString ); // fix ancient Mac line endings
 						
                         $this->_currentFilename = $filename;
                         

--- a/classes/phpDoctor.php
+++ b/classes/phpDoctor.php
@@ -1245,17 +1245,17 @@ class PHPDoctor
 			'tags' => array()
 		);
 		
-		$explodedComment = preg_split('/[\n|\r][ \r\n\t\/]*\*[ \t]*@/', "\n".$comment);
+		$explodedComment = preg_split('/\n[ \n\t\/]*\*[ \t]*@/', "\n".$comment);
 		
 		preg_match_all('/^[ \t\/*]*\** ?(.*)[ \t\/*]*$/m', array_shift($explodedComment), $matches);
 		if (isset($matches[1])) {
-			$data['tags']['@text'] = $this->createTag('@text', trim(implode("\n", $matches[1]), " \n\r\t\0\x0B*/"), $data, $root);
+			$data['tags']['@text'] = $this->createTag('@text', trim(implode("\n", $matches[1]), " \n\t\0\x0B*/"), $data, $root);
 		}
 		
 		foreach ($explodedComment as $tag) { // process tags
             // strip whitespace, newlines and asterisks
-            $tag = preg_replace('/(^[\s\n\r\*]+|\s*\*\/$)/m', ' ', $tag);
-            $tag = preg_replace('/[\r\n]+/', '', $tag);
+            $tag = preg_replace('/(^[\s\n\*]+|\s*\*\/$)/m', ' ', $tag);
+            $tag = preg_replace('/[\n]+/', '', $tag);
             $tag = trim($tag);
 			
 			$parts = preg_split('/\s+/', $tag);

--- a/tests/cases/data/testcase-linefeed.php
+++ b/tests/cases/data/testcase-linefeed.php
@@ -1,0 +1,15 @@
+<?php
+    
+    /**
+     * Testing linefeeds.
+     *
+     * This is the second paragraph.
+     *
+     * This is the third, extending into
+     * a second short line.
+     *
+     * @author Foo
+     */
+    class LineFeed {}
+    
+?>

--- a/tests/cases/ini/linefeed.ini
+++ b/tests/cases/ini/linefeed.ini
@@ -1,0 +1,10 @@
+files = "testcase-linefeed.php"
+source_path = "cases/tmp"
+ignore = "CVS, _compiled"
+verbose = on
+quiet = off
+doclet = standard
+default_package = "PHPDoctor\Tests"
+private = on
+protected = on
+d = "../output"

--- a/tests/cases/linefeed.php
+++ b/tests/cases/linefeed.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @package PHPDoctor\Tests
+ */
+class TestLinefeed extends DoctorTestCase
+{
+	
+    var $src, $cmd;
+    
+	function testLinefeed() {
+        $this->DoctorTestCase('Linefeed tests');
+		
+		// The source file must be generated on the fly because the line endings are converted to Unix when
+		// pulling/pushing the repo. 
+		
+		$src = file_get_contents('tests/cases/data/testcase-linefeed.php', true);
+		
+		$src = str_replace("\r\n", "\n", $src);
+		$this->src = str_replace("\r", "\n", $src);	// for those ancient Macs still out there
+		
+		$this->setIniFile('linefeed.ini');
+	}
+	
+	function testParagraphsLF() {
+		
+		$this->clearTempDir();
+		$this->clearOutputDir();
+		
+		file_put_contents(dirname(__file__).'/tmp/testcase-linefeed.php', $this->src, FILE_USE_INCLUDE_PATH);
+		
+		$this->runPhpDoctor();
+		$results = $this->readOutputFile('phpdoctor/tests/linefeed.html');
+		
+		$this->assertStringContains('<p>Testing linefeeds.</p>', $results, true);
+		$this->assertStringContains('<p>This is the second paragraph.</p>', $results, true);
+		$this->assertStringContains('<p>This is the third, extending into a second short line.</p>', $results, true);
+	}
+	
+	function testParagraphsCRLF() {
+		
+		$this->clearTempDir();
+		$this->clearOutputDir();
+		
+		$src = str_replace("\n", "\r\n", $this->src);
+		
+		file_put_contents('tests/cases/tmp/testcase-linefeed.php', $src, FILE_USE_INCLUDE_PATH);
+		
+		$this->runPhpDoctor();
+		$results = $this->readOutputFile('phpdoctor/tests/linefeed.html');
+		
+		$this->assertStringContains('<p>Testing linefeeds.</p>', $results, true);
+		$this->assertStringContains('<p>This is the second paragraph.</p>', $results, true);
+		$this->assertStringContains('<p>This is the third, extending into a second short line.</p>', $results, true);
+	}
+	
+	function testParagraphsCR() {
+		
+		$this->clearTempDir();
+		$this->clearOutputDir();
+		
+		$src = str_replace("\n", "\r", $this->src);
+		
+		file_put_contents('tests/cases/tmp/testcase-linefeed.php', $src, FILE_USE_INCLUDE_PATH);
+		
+		$this->runPhpDoctor();
+		$results = $this->readOutputFile('phpdoctor/tests/linefeed.html');
+		
+		$this->assertStringContains('<p>Testing linefeeds.</p>', $results, true);
+		$this->assertStringContains('<p>This is the second paragraph.</p>', $results, true);
+		$this->assertStringContains('<p>This is the third, extending into a second short line.</p>', $results, true);
+	}
+	
+}
+
+?>

--- a/tests/doctorTestCase.php
+++ b/tests/doctorTestCase.php
@@ -1,0 +1,195 @@
+<?php
+    require_once 'simpletest'.DIRECTORY_SEPARATOR.'unit_tester.php';
+	
+    class DoctorTestCase extends UnitTestCase {
+        
+        var $iniPath, $appDir, $testDir, $caseDir, $iniDir, $outputDir, $tempDir;
+        
+        function DoctorTestCase ($label = false) {
+			$this->UnitTestCase($label);
+			
+            $this->appDir    = dirname(dirname(__file__)).DIRECTORY_SEPARATOR;
+			$this->testDir   = $this->appDir.'tests'.DIRECTORY_SEPARATOR;
+			$this->caseDir   = $this->testDir.'cases'.DIRECTORY_SEPARATOR;
+            $this->iniDir 	 = $this->caseDir.'ini'.DIRECTORY_SEPARATOR;
+            $this->outputDir = $this->caseDir.'output'.DIRECTORY_SEPARATOR;
+            $this->tempDir   = $this->caseDir.'temp'.DIRECTORY_SEPARATOR;
+        }
+        
+        function setIniFile( $iniFileName ) {
+            $this->iniPath = $this->iniDir.$iniFileName;
+        }
+        
+        /**
+         * Command line invocation to run PHPDoctor, independent of OS and include dir settings.
+         * Call setIniFile first.
+         *
+         * @return string 	PHPDoctor messages
+         */
+        function runPhpDoctor () {
+            if (!file_exists($this->iniPath)) exit("\n\nini file for test not found or undefined\n\n");
+            
+            $errorReporting = (string)(error_reporting() & ~2048); // Make sure E_STRICT is disabled
+            
+			ob_start();
+            passthru(PHP . " -d error_reporting=$errorReporting \"{$this->appDir}phpdoc.php\" \"{$this->iniPath}\"");
+			return ob_get_clean();
+        }
+        
+        function readOutputFile($filename) {
+            return file_get_contents('cases/output/'.$filename);
+        }
+		
+		/**
+		 * Reports an error if the $string does not contain $expected.
+		 *
+		 * Can be set to ignore insignificant whitespace in HTML output. Any whitespace in $expected is then
+		 * allowed to be expanded in $string.
+		 *
+		 * If you want to capture whitespace in $string which may also be completely absent, use a pipe in
+		 * $expected (e.g. '<td>|<tr>A cell</tr>|</td>'). If $expected happens to contain a literal pipe,
+		 * escape it with another pipe ('||').
+		 * 
+		 * @param string $expected                     the needle
+		 * @param string $string                       the haystack
+		 * @param bool   $ignoreInsigificantWhitespace allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function assertStringContains( $expected, $string, $ignoreInsigificantWhitespace = false ) {
+			
+			$contained = $this->inStr($string, $expected, $ignoreInsigificantWhitespace);
+			return $this->assertTrue($contained);
+			
+		}
+	
+		/**
+		 * Reports an error if the $string contains $expected. Inverse of assertStringContains().
+		 *
+		 * @param string $expected                     the needle
+		 * @param string $string                       the haystack
+		 * @param bool   $ignoreInsigificantWhitespace allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function assertStringDoesNotContain( $expected, $string, $ignoreInsigificantWhitespace = false ) {
+			
+			$contained = $this->inStr($string, $expected, $ignoreInsigificantWhitespace);
+			return $this->assertFalse($contained);
+			
+		}
+		
+		/**
+		 * Returns if $haystack contains $needle. 
+		 *
+		 * Can be set to ignore insignificant whitespace in HTML output. Any whitespace in $expected is then
+		 * allowed to be expanded in $string.
+		 *
+		 * If you want to capture whitespace in $string which may also be completely absent, use a pipe in
+		 * $expected (e.g. '<td>|<tr>A cell</tr>|</td>'). If $expected happens to contain a literal pipe,
+		 * escape it with another pipe ('||').
+		 * 
+		 * (Quick and dirty solution for pipe escaping. Will get off track if the needle contains a chr(1) -
+		 * which is rather unlikely.)
+		 * 
+		 * @param string $haystack                     the haystack
+		 * @param string $needle                       the needle (oh, really?!)
+		 * @param bool $ignoreInsigificantWhitespace   allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function inStr( $haystack, $needle, $ignoreInsigificantWhitespace = false ) {
+			
+			if ($ignoreInsigificantWhitespace) {
+				$needle = preg_quote($needle, '/');
+				
+				$needle = str_replace('\|\|', chr(1), $needle);
+				$needle = preg_replace('%\\\\\|\s+%', ' ', $needle);
+				$needle = preg_replace('%\s+\\\\\|%', ' ', $needle);
+				$needle = str_replace('\|', '\s*', $needle);
+				$needle = str_replace(chr(1), '\|', $needle);
+				
+				$needle = preg_replace('/\s+/', '\\s+', $needle);
+				
+				$contained = (bool) preg_match("/$needle/", $haystack);
+			} else {
+				$contained = (strpos($haystack, $needle)!==false);
+			}
+			
+			return $contained;
+		}
+		
+		/**
+		 * Reports an error if the $string does not contain $expected. $expected is a regular expression including 
+		 * delimiters and any modifiers.
+		 *
+		 * @param string $expected                     the needle, as a regular expression
+		 * @param string $string                       the haystack
+		 * 
+		 * @return bool
+		 */
+		function assertStringContainsRx( $expectedRx, $string ) {
+			
+			$contained = $this->inStrRx($string, $expectedRx);
+			return $this->assertTrue($contained);
+			
+		}
+		
+		/**
+		 * Reports an error if the $string contains $expected. Inverse of assertStringContainsRx().
+		 *
+		 * @param string $expected                     the needle, as a regular expression
+		 * @param string $string                       the haystack
+		 * 
+		 * @return bool
+		 */
+		function assertStringDoesNotContainRx( $expectedRx, $string ) {
+			
+			$contained = $this->inStrRx($string, $expectedRx);
+			return $this->assertFalse($contained);
+			
+		}
+		
+		/**
+		 * Returns if $haystack contains $needle. $needle is a regular expression including delimiters and modifiers.
+		 *
+		 * @param string $haystack                     the haystack
+		 * @param string $needle                       the needle, as a regular expression.
+		 * 
+		 * @return bool
+		 */
+		function inStrRx( $haystack, $needle ) {
+			
+			$contained = (bool) preg_match($needle, $haystack);
+			
+			return $contained;
+		}
+		
+		function clearTempDir() {
+			$this->removeDir($this->tempDir);
+		}
+		
+		function clearOutputDir() {
+			$this->removeDir($this->outputDir);
+		}
+		
+		function removeDir($dir) {
+			
+			if(file_exists($dir)){
+				foreach ( new DirectoryIterator($dir) as $file ) {
+					if ( $file->isDir() ) {
+						if ( !$file->isDot() ) {
+							$this->removeDir($file->getPathname());
+						} 
+					} else {
+						unlink($file->getPathname());
+					}
+				}
+				
+				rmdir($dir);
+			}
+		}
+		
+    }
+    
+?>

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,26 @@
+<?php
+    
+    /**
+     * Start the testsuite here.
+     *
+     * Will adjust error reporting. For clean results, this has to be done outside of the file where the testsuite
+     * is actually built (test.php).
+     *
+     * Makes sure the test dirs are in the include path.
+     */
+    
+    error_reporting(error_reporting() & ~2048); // Make sure E_STRICT is disabled
+    
+    $testdir = dirname(__FILE__).DIRECTORY_SEPARATOR;
+    $casedir = $testdir.'cases'.DIRECTORY_SEPARATOR;
+    
+    set_include_path(get_include_path().PATH_SEPARATOR.$testdir.PATH_SEPARATOR.dirname($testdir)); // make sure the phpDoctor dirs are in the include path
+    chdir($testdir);
+    
+    if (!file_exists($casedir.'tmp')) mkdir( $casedir.'tmp');
+    if (!file_exists($casedir.'output')) mkdir( $casedir.'output');
+    
+    require_once 'doctorTestCase.php';
+    include('test.php');
+    
+?>

--- a/tests/test.php
+++ b/tests/test.php
@@ -22,9 +22,13 @@ $parser->addTestFile('tests'.DIRECTORY_SEPARATOR.'use-class-path-as-package.php'
 $standardDoclet = &new GroupTest('Standard Doclet');
 $standardDoclet->addTestFile('tests'.DIRECTORY_SEPARATOR.'standard-doclet.php');
 
+$fixes = &new GroupTest('Bugfixes'); // these tests will work with PHP5 < 5.3
+$fixes->addTestFile('tests'.DIRECTORY_SEPARATOR.'cases'.DIRECTORY_SEPARATOR.'linefeed.php');
+
 $test = &new GroupTest('PHPDoctor');
-$test->addTestCase($parser);
+#$test->addTestCase($parser);
 #$test->addTestCase($standardDoclet);
+$test->addTestCase($fixes);
 
 if (TextReporter::inCli()) {
 	exit ($test->run(new TextReporter()) ? 0 : 1);


### PR DESCRIPTION
Hi,

phpdoctor has trouble processing files generated on Windows. The docblock description is turned into a single unstructured paragraph. Here's a testcase and a fix.
