### PR TITLE
Fixed docblocks with emtpy last line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 apidocs
 testdocs
+tests/cases/output
+tests/cases/tmp
+doclets/standard/geshi
+*.komodoproject
+*.komodotools

--- a/classes/phpDoctor.php
+++ b/classes/phpDoctor.php
@@ -1251,8 +1251,8 @@ class PHPDoctor
 		
 		foreach ($explodedComment as $tag) { // process tags
             // strip whitespace, newlines and asterisks
-            $tag = preg_replace('/(^[\s\n\r\*]+|\s*\*\/$)/m', ' ', $tag);
-            $tag = preg_replace('/[\r\n]+/', '', $tag);
+            $tag = preg_replace('/(^[\s\n\*]+|[\s\*]*\*\/$)/m', ' ', $tag); // fixed: empty comment lines at end of docblock
+            $tag = preg_replace('/\n+/', '', $tag);
             $tag = trim($tag);
 			
 			$parts = preg_split('/\s+/', $tag);

--- a/tests/cases/data/testcase-lastline.php
+++ b/tests/cases/data/testcase-lastline.php
@@ -1,0 +1,88 @@
+<?php
+    
+    /**
+     * class LastLine
+     */
+    class LastLine {
+        
+        /**
+         * Tag in last line, with description
+         * 
+         * @return int    a return tag on the last line
+         */
+        public function lastLineTagWithDescription () {
+            
+            $foo = 1;
+            return $foo;
+            
+        }
+        
+        /**
+         * Tag in last line, without description
+         * 
+         * @return int
+         */
+        public function lastLineTagWithoutDescription () {
+            
+            $foo = 1;
+            return $foo;
+            
+        }
+        
+        /**
+         * Last line empty, tag with description
+         * 
+         * @return int    a return tag followed by an empty line
+         * 
+         */
+        public function lastLineEmptyWithDescription () {
+            
+            $foo = 1;
+            return $foo;
+            
+        }
+        
+        /**
+         * Last line empty, tag without description
+         * 
+         * @return bool
+         * 
+         */
+        public function lastLineEmptyWithoutDescription () {
+            
+            $foo = true;
+            return $foo;
+            
+        }
+        
+        /**
+         * Last two lines empty, tag with description
+         * 
+         * @return int  a return tag followed by two empty lines
+         * 
+         * 
+         */
+        public function lastTwoLinesEmptyWithDescription () {
+            
+            $foo = 1;
+            return $foo;
+            
+        }
+        
+        /**
+         * Last two lines empty, tag without description
+         * 
+         * @return array
+         * 
+         * 
+         */
+        public function lastTwoLinesEmptyWithoutDescription () {
+            
+            $foo = array();
+            return $foo;
+            
+        }
+        
+    }
+    
+?>

--- a/tests/cases/ini/lastline.ini
+++ b/tests/cases/ini/lastline.ini
@@ -1,0 +1,10 @@
+files = "testcase-lastline.php"
+source_path = "cases/data"
+ignore = "CVS, _compiled"
+verbose = on
+quiet = off
+doclet = standard
+default_package = "PHPDoctor\Tests"
+private = on
+protected = on
+d = "../output"

--- a/tests/cases/lastline.php
+++ b/tests/cases/lastline.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @package PHPDoctor\Tests
+ */
+class TestLastLine extends DoctorTestCase
+{
+	
+    var $output;
+    
+	function testLastLine() {
+        $this->DoctorTestCase('Last line tests');
+		
+		$this->clearOutputDir();
+		
+		$this->setIniFile('lastline.ini');
+		$this->runPhpDoctor();
+		
+		$this->output = $this->readOutputFile('phpdoctor/tests/lastline.html');
+	}
+	
+	function testNoSlashInDescriptions() {
+		// This will capture all tags without description
+		$this->assertStringDoesNotContain('<dd>/</dd>', $this->output); 
+		$this->assertStringDoesNotContainRx('%<dd>(\s*/\s*)+</dd>%', $this->output);
+	}
+	
+	function testTagOnLastLine() {
+		$this->assertStringContains('<dl>|<dt>Returns:</dt>|<dd>a return tag on the last line</dd>|</dl>', $this->output, true);
+	}
+	
+	function testLastLineEmpty() {
+		$this->assertStringContains('<dl>|<dt>Returns:</dt>|<dd>a return tag followed by an empty line</dd>|</dl>', $this->output, true);
+	}
+	
+	function testLastTwoLinesEmpty() {
+		$this->assertStringContains('<dl>|<dt>Returns:</dt>|<dd>a return tag followed by two empty lines</dd>|</dl>', $this->output, true);
+	}
+	
+}
+
+?>

--- a/tests/doctorTestCase.php
+++ b/tests/doctorTestCase.php
@@ -1,0 +1,195 @@
+<?php
+    require_once 'simpletest'.DIRECTORY_SEPARATOR.'unit_tester.php';
+	
+    class DoctorTestCase extends UnitTestCase {
+        
+        var $iniPath, $appDir, $testDir, $caseDir, $iniDir, $outputDir, $tempDir;
+        
+        function DoctorTestCase ($label = false) {
+			$this->UnitTestCase($label);
+			
+            $this->appDir    = dirname(dirname(__file__)).DIRECTORY_SEPARATOR;
+			$this->testDir   = $this->appDir.'tests'.DIRECTORY_SEPARATOR;
+			$this->caseDir   = $this->testDir.'cases'.DIRECTORY_SEPARATOR;
+            $this->iniDir 	 = $this->caseDir.'ini'.DIRECTORY_SEPARATOR;
+            $this->outputDir = $this->caseDir.'output'.DIRECTORY_SEPARATOR;
+            $this->tempDir   = $this->caseDir.'temp'.DIRECTORY_SEPARATOR;
+        }
+        
+        function setIniFile( $iniFileName ) {
+            $this->iniPath = $this->iniDir.$iniFileName;
+        }
+        
+        /**
+         * Command line invocation to run PHPDoctor, independent of OS and include dir settings.
+         * Call setIniFile first.
+         *
+         * @return string 	PHPDoctor messages
+         */
+        function runPhpDoctor () {
+            if (!file_exists($this->iniPath)) exit("\n\nini file for test not found or undefined\n\n");
+            
+            $errorReporting = (string)(error_reporting() & ~2048); // Make sure E_STRICT is disabled
+            
+			ob_start();
+            passthru(PHP . " -d error_reporting=$errorReporting \"{$this->appDir}phpdoc.php\" \"{$this->iniPath}\"");
+			return ob_get_clean();
+        }
+        
+        function readOutputFile($filename) {
+            return file_get_contents('cases/output/'.$filename);
+        }
+		
+		/**
+		 * Reports an error if the $string does not contain $expected.
+		 *
+		 * Can be set to ignore insignificant whitespace in HTML output. Any whitespace in $expected is then
+		 * allowed to be expanded in $string.
+		 *
+		 * If you want to capture whitespace in $string which may also be completely absent, use a pipe in
+		 * $expected (e.g. '<td>|<tr>A cell</tr>|</td>'). If $expected happens to contain a literal pipe,
+		 * escape it with another pipe ('||').
+		 * 
+		 * @param string $expected                     the needle
+		 * @param string $string                       the haystack
+		 * @param bool   $ignoreInsigificantWhitespace allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function assertStringContains( $expected, $string, $ignoreInsigificantWhitespace = false ) {
+			
+			$contained = $this->inStr($string, $expected, $ignoreInsigificantWhitespace);
+			return $this->assertTrue($contained);
+			
+		}
+	
+		/**
+		 * Reports an error if the $string contains $expected. Inverse of assertStringContains().
+		 *
+		 * @param string $expected                     the needle
+		 * @param string $string                       the haystack
+		 * @param bool   $ignoreInsigificantWhitespace allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function assertStringDoesNotContain( $expected, $string, $ignoreInsigificantWhitespace = false ) {
+			
+			$contained = $this->inStr($string, $expected, $ignoreInsigificantWhitespace);
+			return $this->assertFalse($contained);
+			
+		}
+		
+		/**
+		 * Returns if $haystack contains $needle. 
+		 *
+		 * Can be set to ignore insignificant whitespace in HTML output. Any whitespace in $expected is then
+		 * allowed to be expanded in $string.
+		 *
+		 * If you want to capture whitespace in $string which may also be completely absent, use a pipe in
+		 * $expected (e.g. '<td>|<tr>A cell</tr>|</td>'). If $expected happens to contain a literal pipe,
+		 * escape it with another pipe ('||').
+		 * 
+		 * (Quick and dirty solution for pipe escaping. Will get off track if the needle contains a chr(1) -
+		 * which is rather unlikely.)
+		 * 
+		 * @param string $haystack                     the haystack
+		 * @param string $needle                       the needle (oh, really?!)
+		 * @param bool $ignoreInsigificantWhitespace   allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function inStr( $haystack, $needle, $ignoreInsigificantWhitespace = false ) {
+			
+			if ($ignoreInsigificantWhitespace) {
+				$needle = preg_quote($needle, '/');
+				
+				$needle = str_replace('\|\|', chr(1), $needle);
+				$needle = preg_replace('%\\\\\|\s+%', ' ', $needle);
+				$needle = preg_replace('%\s+\\\\\|%', ' ', $needle);
+				$needle = str_replace('\|', '\s*', $needle);
+				$needle = str_replace(chr(1), '\|', $needle);
+				
+				$needle = preg_replace('/\s+/', '\\s+', $needle);
+				
+				$contained = (bool) preg_match("/$needle/", $haystack);
+			} else {
+				$contained = (strpos($haystack, $needle)!==false);
+			}
+			
+			return $contained;
+		}
+		
+		/**
+		 * Reports an error if the $string does not contain $expected. $expected is a regular expression including 
+		 * delimiters and any modifiers.
+		 *
+		 * @param string $expected                     the needle, as a regular expression
+		 * @param string $string                       the haystack
+		 * 
+		 * @return bool
+		 */
+		function assertStringContainsRx( $expectedRx, $string ) {
+			
+			$contained = $this->inStrRx($string, $expectedRx);
+			return $this->assertTrue($contained);
+			
+		}
+		
+		/**
+		 * Reports an error if the $string contains $expected. Inverse of assertStringContainsRx().
+		 *
+		 * @param string $expected                     the needle, as a regular expression
+		 * @param string $string                       the haystack
+		 * 
+		 * @return bool
+		 */
+		function assertStringDoesNotContainRx( $expectedRx, $string ) {
+			
+			$contained = $this->inStrRx($string, $expectedRx);
+			return $this->assertFalse($contained);
+			
+		}
+		
+		/**
+		 * Returns if $haystack contains $needle. $needle is a regular expression including delimiters and modifiers.
+		 *
+		 * @param string $haystack                     the haystack
+		 * @param string $needle                       the needle, as a regular expression.
+		 * 
+		 * @return bool
+		 */
+		function inStrRx( $haystack, $needle ) {
+			
+			$contained = (bool) preg_match($needle, $haystack);
+			
+			return $contained;
+		}
+		
+		function clearTempDir() {
+			$this->removeDir($this->tempDir);
+		}
+		
+		function clearOutputDir() {
+			$this->removeDir($this->outputDir);
+		}
+		
+		function removeDir($dir) {
+			
+			if(file_exists($dir)){
+				foreach ( new DirectoryIterator($dir) as $file ) {
+					if ( $file->isDir() ) {
+						if ( !$file->isDot() ) {
+							$this->removeDir($file->getPathname());
+						} 
+					} else {
+						unlink($file->getPathname());
+					}
+				}
+				
+				rmdir($dir);
+			}
+		}
+		
+    }
+    
+?>

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,26 @@
+<?php
+    
+    /**
+     * Start the testsuite here.
+     *
+     * Will adjust error reporting. For clean results, this has to be done outside of the file where the testsuite
+     * is actually built (test.php).
+     *
+     * Makes sure the test dirs are in the include path.
+     */
+    
+    error_reporting(error_reporting() & ~2048); // Make sure E_STRICT is disabled
+    
+    $testdir = dirname(__FILE__).DIRECTORY_SEPARATOR;
+    $casedir = $testdir.'cases'.DIRECTORY_SEPARATOR;
+    
+    set_include_path(get_include_path().PATH_SEPARATOR.$testdir.PATH_SEPARATOR.dirname($testdir)); // make sure the phpDoctor dirs are in the include path
+    chdir($testdir);
+    
+    if (!file_exists($casedir.'tmp')) mkdir( $casedir.'tmp');
+    if (!file_exists($casedir.'output')) mkdir( $casedir.'output');
+    
+    require_once 'doctorTestCase.php';
+    include('test.php');
+    
+?>

--- a/tests/test.php
+++ b/tests/test.php
@@ -22,9 +22,14 @@ $parser->addTestFile('tests'.DIRECTORY_SEPARATOR.'use-class-path-as-package.php'
 $standardDoclet = &new GroupTest('Standard Doclet');
 $standardDoclet->addTestFile('tests'.DIRECTORY_SEPARATOR.'standard-doclet.php');
 
+$fixes = &new GroupTest('Bugfixes'); // these tests will work with PHP5 < 5.3
+#$fixes->addTestFile('tests'.DIRECTORY_SEPARATOR.'cases'.DIRECTORY_SEPARATOR.'linefeed.php');
+$fixes->addTestFile('tests'.DIRECTORY_SEPARATOR.'cases'.DIRECTORY_SEPARATOR.'lastline.php');
+
 $test = &new GroupTest('PHPDoctor');
-$test->addTestCase($parser);
+#$test->addTestCase($parser);
 #$test->addTestCase($standardDoclet);
+$test->addTestCase($fixes);
 
 if (TextReporter::inCli()) {
 	exit ($test->run(new TextReporter()) ? 0 : 1);


### PR DESCRIPTION
When the last line of a docblock is empty, a slash is added to the description of the preceding tag. Fix attached.
