### PR TITLE
Fix for class constants and properties with value 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 apidocs
 testdocs
+tests/cases/output
+tests/cases/tmp
+doclets/standard/geshi
+*.komodoproject
+*.komodotools

--- a/doclets/standard/classWriter.php
+++ b/doclets/standard/classWriter.php
@@ -139,7 +139,7 @@ class ClassWriter extends HTMLWriter
 							echo '<td class="type">', $field->modifiers(FALSE), ' ', $field->typeAsString(), "</td>\n";
 							echo '<td class="description">';
 							echo '<p class="name"><a href="#', $field->name(), '">';
-							if (!$field->constantValue()) echo '$';
+							if (is_null($field->constantValue())) echo '$';
 							echo $field->name(), '</a></p>';
 							if ($textTag) {
 								echo '<p class="description">', strip_tags($this->_processInlineTags($textTag, TRUE), '<a><b><strong><u><em>'), '</p>';
@@ -159,7 +159,7 @@ class ClassWriter extends HTMLWriter
 							echo '<td class="type">', $field->modifiers(FALSE), ' ', $field->typeAsString(), "</td>\n";
 							echo '<td class="description">';
 							echo '<p class="name"><a href="#', $field->name(), '">';
-							if (!$field->constantValue()) echo '$';
+							if (is_null($field->constantValue())) echo '$';
 							echo $field->name(), '</a></p>';
 							if ($textTag) {
 								echo '<p class="description">', strip_tags($this->_processInlineTags($textTag, TRUE), '<a><b><strong><u><em>'), '</p>';
@@ -210,9 +210,9 @@ class ClassWriter extends HTMLWriter
 							$this->_sourceLocation($field);
 							echo '<h3 id="', $field->name(),'">', $field->name(), "</h3>\n";
 							echo '<code class="signature">', $field->modifiers(), ' ', $field->typeAsString(), ' <strong>';
-							if (!$field->constantValue()) echo '$';
+							if (is_null($field->constantValue())) echo '$';
 							echo $field->name(), '</strong>';
-							if ($field->value()) echo ' = ', htmlspecialchars($field->value());
+							if (!is_null($field->value())) echo ' = ', htmlspecialchars($field->value());
 							echo "</code>\n";
                             echo '<div class="details">', "\n";
 							if ($textTag) {
@@ -232,9 +232,9 @@ class ClassWriter extends HTMLWriter
 							$this->_sourceLocation($field);
 							echo '<h3 id="', $field->name(),'">', $field->name(), "</h3>\n";
 							echo '<code class="signature">', $field->modifiers(), ' ', $field->typeAsString(), ' <strong>';
-							if (!$field->constantValue()) echo '$';
+							if (is_null($field->constantValue())) echo '$';
 							echo $field->name(), '</strong>';
-							if ($field->value()) echo ' = ', htmlspecialchars($field->value());
+							if (!is_null($field->value())) echo ' = ', htmlspecialchars($field->value());
 							echo "</code>\n";
                             echo '<div class="details">', "\n";
 							if ($textTag) {

--- a/tests/cases/data/testcase-zerovalue.php
+++ b/tests/cases/data/testcase-zerovalue.php
@@ -1,0 +1,30 @@
+<?php
+    
+    /**
+     * class ZeroValue
+     */
+    class ZeroValue {
+        
+        const ZERO = 0;
+        const ONE = 1;
+        
+        const EMPTY_STRING = '';
+        const SOME_STRING = 'whatever const';
+        
+        const NULL_CONST = null;
+        
+        public $prop_zero = 0;
+        public $prop_one = 1;
+        
+        public $prop_emptystring = '';
+        public $prop_somestring = 'whatever string';
+        
+        public $prop_null = null;
+        
+        public $prop_undefined;
+        
+    }
+    
+    
+    
+?>

--- a/tests/cases/ini/zerovalue.ini
+++ b/tests/cases/ini/zerovalue.ini
@@ -1,0 +1,10 @@
+files = "testcase-zerovalue.php"
+source_path = "cases/data"
+ignore = "CVS, _compiled"
+verbose = on
+quiet = off
+doclet = standard
+default_package = "PHPDoctor\Tests"
+private = on
+protected = on
+d = "../output"

--- a/tests/cases/zerovalue.php
+++ b/tests/cases/zerovalue.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @package PHPDoctor\Tests
+ */
+class TestZeroValue extends DoctorTestCase
+{
+	
+    var $output;
+    
+	function testZeroValue() {
+        $this->DoctorTestCase('Zero Value tests');
+		
+		$this->clearOutputDir();
+		
+		$this->setIniFile('zerovalue.ini');
+		$this->runPhpDoctor();
+		
+		$this->output = $this->readOutputFile('phpdoctor/tests/zerovalue.html');
+	}
+	
+	function testConstIntZero() {
+		$this->assertStringDoesNotContain('<p class="name">|<a href="#ZERO">$ZERO</a>|</p>', $this->output, true);
+		$this->assertStringDoesNotContain('<code class="signature">public final static  int <strong>$ZERO</strong></code>', $this->output, true);
+		
+		$this->assertStringContains('<p class="name">|<a href="#ZERO">ZERO</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="ZERO">ZERO</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public final static  int <strong>ZERO</strong> = 0</code>', $this->output, true); 
+	}
+	
+	function testConstIntOne() {
+		$this->assertStringContains('<p class="name">|<a href="#ONE">ONE</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="ONE">ONE</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public final static  int <strong>ONE</strong> = 1</code>', $this->output, true); 
+	}
+	
+	function testConstEmptyString() {
+		$this->assertStringContains('<p class="name">|<a href="#EMPTY_STRING">EMPTY_STRING</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="EMPTY_STRING">EMPTY_STRING</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public final static  str <strong>EMPTY_STRING</strong> = \'\'</code>', $this->output, true); 
+	}
+	
+	function testConstNonEmptyString() {
+		$this->assertStringContains('<p class="name">|<a href="#SOME_STRING">SOME_STRING</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="SOME_STRING">SOME_STRING</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public final static  str <strong>SOME_STRING</strong> = \'whatever const\'</code>', $this->output, true); 
+	}
+	
+	function testConstNull() {
+		$this->assertStringContains('<p class="name">|<a href="#NULL_CONST">NULL_CONST</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="NULL_CONST">NULL_CONST</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public final static  mixed <strong>NULL_CONST</strong> = null</code>', $this->output, true); 
+	}
+	
+	function testPropIntZero() {
+		
+		$this->assertStringDoesNotContain('<code class="signature">public  mixed <strong>$prop_zero</strong></code>', $this->output, true);
+		
+		$this->assertStringContains('<p class="name">|<a href="#prop_zero">$prop_zero</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="prop_zero">prop_zero</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public  mixed <strong>$prop_zero</strong> = 0</code>', $this->output, true); 
+	}
+	
+	function testPropIntOne() {
+		$this->assertStringContains('<p class="name">|<a href="#prop_one">$prop_one</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="prop_one">prop_one</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public  mixed <strong>$prop_one</strong> = 1</code>', $this->output, true); 
+	}
+	
+	function testPropEmptyString() {
+		$this->assertStringContains('<p class="name">|<a href="#prop_emptystring">$prop_emptystring</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="prop_emptystring">prop_emptystring</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public  mixed <strong>$prop_emptystring</strong> = \'\'</code>', $this->output, true); 
+	}
+	
+	function testPropNonEmptyString() {
+		$this->assertStringContains('<p class="name">|<a href="#prop_somestring">$prop_somestring</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="prop_somestring">prop_somestring</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public  mixed <strong>$prop_somestring</strong> = \'whatever string\'</code>', $this->output, true); 
+	}
+	
+	function testPropNull() {
+		$this->assertStringContains('<p class="name">|<a href="#prop_null">$prop_null</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="prop_null">prop_null</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public  mixed <strong>$prop_null</strong> = null</code>', $this->output, true); 
+	}
+	
+	function testPropUndefined() {
+		$this->assertStringContains('<p class="name">|<a href="#prop_undefined">$prop_undefined</a>|</p>', $this->output, true); 
+		$this->assertStringContains('<h3 id="prop_undefined">prop_undefined</h3>', $this->output, true); 
+		$this->assertStringContains('<code class="signature">public  mixed <strong>$prop_undefined</strong></code>', $this->output, true); 
+	}
+	
+	
+}
+
+?>

--- a/tests/doctorTestCase.php
+++ b/tests/doctorTestCase.php
@@ -1,0 +1,195 @@
+<?php
+    require_once 'simpletest'.DIRECTORY_SEPARATOR.'unit_tester.php';
+	
+    class DoctorTestCase extends UnitTestCase {
+        
+        var $iniPath, $appDir, $testDir, $caseDir, $iniDir, $outputDir, $tempDir;
+        
+        function DoctorTestCase ($label = false) {
+			$this->UnitTestCase($label);
+			
+            $this->appDir    = dirname(dirname(__file__)).DIRECTORY_SEPARATOR;
+			$this->testDir   = $this->appDir.'tests'.DIRECTORY_SEPARATOR;
+			$this->caseDir   = $this->testDir.'cases'.DIRECTORY_SEPARATOR;
+            $this->iniDir 	 = $this->caseDir.'ini'.DIRECTORY_SEPARATOR;
+            $this->outputDir = $this->caseDir.'output'.DIRECTORY_SEPARATOR;
+            $this->tempDir   = $this->caseDir.'temp'.DIRECTORY_SEPARATOR;
+        }
+        
+        function setIniFile( $iniFileName ) {
+            $this->iniPath = $this->iniDir.$iniFileName;
+        }
+        
+        /**
+         * Command line invocation to run PHPDoctor, independent of OS and include dir settings.
+         * Call setIniFile first.
+         *
+         * @return string 	PHPDoctor messages
+         */
+        function runPhpDoctor () {
+            if (!file_exists($this->iniPath)) exit("\n\nini file for test not found or undefined\n\n");
+            
+            $errorReporting = (string)(error_reporting() & ~2048); // Make sure E_STRICT is disabled
+            
+			ob_start();
+            passthru(PHP . " -d error_reporting=$errorReporting \"{$this->appDir}phpdoc.php\" \"{$this->iniPath}\"");
+			return ob_get_clean();
+        }
+        
+        function readOutputFile($filename) {
+            return file_get_contents('cases/output/'.$filename);
+        }
+		
+		/**
+		 * Reports an error if the $string does not contain $expected.
+		 *
+		 * Can be set to ignore insignificant whitespace in HTML output. Any whitespace in $expected is then
+		 * allowed to be expanded in $string.
+		 *
+		 * If you want to capture whitespace in $string which may also be completely absent, use a pipe in
+		 * $expected (e.g. '<td>|<tr>A cell</tr>|</td>'). If $expected happens to contain a literal pipe,
+		 * escape it with another pipe ('||').
+		 * 
+		 * @param string $expected                     the needle
+		 * @param string $string                       the haystack
+		 * @param bool   $ignoreInsigificantWhitespace allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function assertStringContains( $expected, $string, $ignoreInsigificantWhitespace = false ) {
+			
+			$contained = $this->inStr($string, $expected, $ignoreInsigificantWhitespace);
+			return $this->assertTrue($contained);
+			
+		}
+	
+		/**
+		 * Reports an error if the $string contains $expected. Inverse of assertStringContains().
+		 *
+		 * @param string $expected                     the needle
+		 * @param string $string                       the haystack
+		 * @param bool   $ignoreInsigificantWhitespace allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function assertStringDoesNotContain( $expected, $string, $ignoreInsigificantWhitespace = false ) {
+			
+			$contained = $this->inStr($string, $expected, $ignoreInsigificantWhitespace);
+			return $this->assertFalse($contained);
+			
+		}
+		
+		/**
+		 * Returns if $haystack contains $needle. 
+		 *
+		 * Can be set to ignore insignificant whitespace in HTML output. Any whitespace in $expected is then
+		 * allowed to be expanded in $string.
+		 *
+		 * If you want to capture whitespace in $string which may also be completely absent, use a pipe in
+		 * $expected (e.g. '<td>|<tr>A cell</tr>|</td>'). If $expected happens to contain a literal pipe,
+		 * escape it with another pipe ('||').
+		 * 
+		 * (Quick and dirty solution for pipe escaping. Will get off track if the needle contains a chr(1) -
+		 * which is rather unlikely.)
+		 * 
+		 * @param string $haystack                     the haystack
+		 * @param string $needle                       the needle (oh, really?!)
+		 * @param bool $ignoreInsigificantWhitespace   allows for additional space, tab and newline chars
+		 * 
+		 * @return bool
+		 */
+		function inStr( $haystack, $needle, $ignoreInsigificantWhitespace = false ) {
+			
+			if ($ignoreInsigificantWhitespace) {
+				$needle = preg_quote($needle, '/');
+				
+				$needle = str_replace('\|\|', chr(1), $needle);
+				$needle = preg_replace('%\\\\\|\s+%', ' ', $needle);
+				$needle = preg_replace('%\s+\\\\\|%', ' ', $needle);
+				$needle = str_replace('\|', '\s*', $needle);
+				$needle = str_replace(chr(1), '\|', $needle);
+				
+				$needle = preg_replace('/\s+/', '\\s+', $needle);
+				
+				$contained = (bool) preg_match("/$needle/", $haystack);
+			} else {
+				$contained = (strpos($haystack, $needle)!==false);
+			}
+			
+			return $contained;
+		}
+		
+		/**
+		 * Reports an error if the $string does not contain $expected. $expected is a regular expression including 
+		 * delimiters and any modifiers.
+		 *
+		 * @param string $expected                     the needle, as a regular expression
+		 * @param string $string                       the haystack
+		 * 
+		 * @return bool
+		 */
+		function assertStringContainsRx( $expectedRx, $string ) {
+			
+			$contained = $this->inStrRx($string, $expectedRx);
+			return $this->assertTrue($contained);
+			
+		}
+		
+		/**
+		 * Reports an error if the $string contains $expected. Inverse of assertStringContainsRx().
+		 *
+		 * @param string $expected                     the needle, as a regular expression
+		 * @param string $string                       the haystack
+		 * 
+		 * @return bool
+		 */
+		function assertStringDoesNotContainRx( $expectedRx, $string ) {
+			
+			$contained = $this->inStrRx($string, $expectedRx);
+			return $this->assertFalse($contained);
+			
+		}
+		
+		/**
+		 * Returns if $haystack contains $needle. $needle is a regular expression including delimiters and modifiers.
+		 *
+		 * @param string $haystack                     the haystack
+		 * @param string $needle                       the needle, as a regular expression.
+		 * 
+		 * @return bool
+		 */
+		function inStrRx( $haystack, $needle ) {
+			
+			$contained = (bool) preg_match($needle, $haystack);
+			
+			return $contained;
+		}
+		
+		function clearTempDir() {
+			$this->removeDir($this->tempDir);
+		}
+		
+		function clearOutputDir() {
+			$this->removeDir($this->outputDir);
+		}
+		
+		function removeDir($dir) {
+			
+			if(file_exists($dir)){
+				foreach ( new DirectoryIterator($dir) as $file ) {
+					if ( $file->isDir() ) {
+						if ( !$file->isDot() ) {
+							$this->removeDir($file->getPathname());
+						} 
+					} else {
+						unlink($file->getPathname());
+					}
+				}
+				
+				rmdir($dir);
+			}
+		}
+		
+    }
+    
+?>

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,26 @@
+<?php
+    
+    /**
+     * Start the testsuite here.
+     *
+     * Will adjust error reporting. For clean results, this has to be done outside of the file where the testsuite
+     * is actually built (test.php).
+     *
+     * Makes sure the test dirs are in the include path.
+     */
+    
+    error_reporting(error_reporting() & ~2048); // Make sure E_STRICT is disabled
+    
+    $testdir = dirname(__FILE__).DIRECTORY_SEPARATOR;
+    $casedir = $testdir.'cases'.DIRECTORY_SEPARATOR;
+    
+    set_include_path(get_include_path().PATH_SEPARATOR.$testdir.PATH_SEPARATOR.dirname($testdir)); // make sure the phpDoctor dirs are in the include path
+    chdir($testdir);
+    
+    if (!file_exists($casedir.'tmp')) mkdir( $casedir.'tmp');
+    if (!file_exists($casedir.'output')) mkdir( $casedir.'output');
+    
+    require_once 'doctorTestCase.php';
+    include('test.php');
+    
+?>

--- a/tests/test.php
+++ b/tests/test.php
@@ -22,9 +22,15 @@ $parser->addTestFile('tests'.DIRECTORY_SEPARATOR.'use-class-path-as-package.php'
 $standardDoclet = &new GroupTest('Standard Doclet');
 $standardDoclet->addTestFile('tests'.DIRECTORY_SEPARATOR.'standard-doclet.php');
 
+$fixes = &new GroupTest('Bugfixes'); // these tests will work with PHP5 < 5.3
+#$fixes->addTestFile('tests'.DIRECTORY_SEPARATOR.'cases'.DIRECTORY_SEPARATOR.'linefeed.php');
+#$fixes->addTestFile('tests'.DIRECTORY_SEPARATOR.'cases'.DIRECTORY_SEPARATOR.'lastline.php');
+$fixes->addTestFile('tests'.DIRECTORY_SEPARATOR.'cases'.DIRECTORY_SEPARATOR.'zerovalue.php');
+
 $test = &new GroupTest('PHPDoctor');
-$test->addTestCase($parser);
+#$test->addTestCase($parser);
 #$test->addTestCase($standardDoclet);
+$test->addTestCase($fixes);
 
 if (TextReporter::inCli()) {
 	exit ($test->run(new TextReporter()) ? 0 : 1);


### PR DESCRIPTION
A class constant with value 0, const WHATEVER = 0, shows up as $WHATEVER in the documentation ($ prefixed, and without a value). Properties don't show a value of 0 either. Here's a fix.
