### PR TITLE
Adding autoguess config file (phpdoctor.ini at executing path).

### DIFF
--- a/phpdoc.php
+++ b/phpdoc.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /*
 PHPDoctor: The PHP Documentation Creator
@@ -39,6 +39,8 @@ require('classes'.DIRECTORY_SEPARATOR.'phpDoctor.php');
 if (!isset($argv[1])) {
     if (isset($_ENV['PHPDoctor'])) {
         $argv[1] = $_ENV['PHPDoctor'];
+    } elseif (is_file(getcwd().'/phpdoctor.ini')) {
+        $argv[1] = getcwd().'/phpdoctor.ini';
     } elseif (is_file('default.ini')) {
         phpDoctor::warning('Using default config file "default.ini"');
         $argv[1] = 'default.ini';


### PR DESCRIPTION
I've added an autoguess config file so it is more convenient to use PHPDoctor in multiple projects. If you set an alias for the modified phpdoc.php (eg. `alias phpdoctor='/path/to/phpdoc.php'` in .bashrc) you only have to add a phpdoctor.ini file to a project and just run `phpdoctor` (please note: i made it executable).

PS: I saw the issue #23 but i'm not that comfortable with PEAR to create a package.
