### PR TITLE
Treat global constant declared using const keyword as global and not class constant

### DIFF
--- a/classes/phpDoctor.php
+++ b/classes/phpDoctor.php
@@ -463,12 +463,14 @@ class PHPDoctor
 		) {
 			return $path;
 		} else {
+		    if (substr($path, 0, 2) == './') {
+		        $path = substr($path, 2);
+		    }
 		    $absPath = $this->fixPath($prefix).$path;
 		    $count = 1;
 		    while ($count > 0) {
 		        $absPath = preg_replace('|\w+/\.\./|', '', $absPath, -1, $count);
 		    }
-		    $absPath = str_replace('./', '', $absPath);
 			return $absPath;
 		}
 	}

--- a/classes/phpDoctor.php
+++ b/classes/phpDoctor.php
@@ -807,9 +807,18 @@ class PHPDoctor
                                     break;
         
                                 case T_STRING:
+                                    $constOutsideOfClass = (isset($tokens[$key - 2][1]) && $tokens[$key - 2][1] == 'const');
+
                                     // read global constant
-                                    if ($token[1] == 'define') {// && $tokens[$key + 2][0] == T_CONSTANT_ENCAPSED_STRING) {
-                                        $const =& new fieldDoc($this->_getNext($tokens, $key, T_CONSTANT_ENCAPSED_STRING), $ce, $rootDoc, $filename, $lineNumber, $this->sourcePath()); // create constant object
+                                    if ($token[1] == 'define' || $constOutsideOfClass) {// && $tokens[$key + 2][0] == T_CONSTANT_ENCAPSED_STRING) {
+                                        if (!$constOutsideOfClass) {
+                                            // Current token is define() function.
+                                            $constantName = $this->_getNext($tokens, $key, T_CONSTANT_ENCAPSED_STRING);
+                                        } else {
+                                            // Current token is constant's name.
+                                            $constantName = $token[1];
+                                        }
+                                        $const =& new fieldDoc($constantName, $ce, $rootDoc, $filename, $lineNumber, $this->sourcePath()); // create constant object
                                         $this->verbose('Found '.get_class($const).': global constant '.$const->name());
                                         $const->set('final', TRUE); // is constant
                                         $value = '';


### PR DESCRIPTION
Distinguish between `const` keyword used inside class definition and not (#50)

PHP 5.3.0 introduced behavior of using `const` keyword in place of `define()` for global constants. `token_get_all()` still treats it as a class constant however.
