### PR TITLE
Support multiple asterisks

### DIFF
--- a/classes/phpDoctor.php
+++ b/classes/phpDoctor.php
@@ -1302,7 +1302,7 @@ class PHPDoctor
 			'tags' => array()
 		);
 		
-		$explodedComment = preg_split('/\n[ \n\t\/]*\*[ \t]*@/', "\n".$comment);
+		$explodedComment = preg_split('/\n[ \n\t\/]*\*+[ \t]*@/', "\n".$comment);
 		
 		preg_match_all('/^[ \t]*[\/*]*\**( ?.*)[ \t\/*]*$/m', array_shift($explodedComment), $matches); // changed; we need the leading whitespace to detect multi-line list entries
 		if (isset($matches[1])) {


### PR DESCRIPTION
This is a one character change to a regex to support multiple asterisks before the text / attribute. The type of javadocs I am using look like this:

```
/** Foo
*** more text
*** @author more */
```

Thanks!
