### PR TITLE
Fixed error where implemented interfaces that have not been parsed will ...

### DIFF
--- a/classes/classDoc.php
+++ b/classes/classDoc.php
@@ -228,19 +228,6 @@ class ClassDoc extends ProgramElementDoc
     {
 		return $this->_interfaces;
 	}
-
-	/** Return an interface in this class.
-	 *
-	 * @return ClassDoc
-	 */
-	function &interfaceNamed($interfaceName)
-    {
-        $return = NULL;
-        if (isset($this->_interfaces[$interfaceName])) {
-            $return =& $this->_interfaces[$interfaceName];
-        }
-        return $return;
-	}
     
 	/** Return true if this class is abstract.
 	 *

--- a/classes/phpDoctor.php
+++ b/classes/phpDoctor.php
@@ -692,11 +692,8 @@ class PHPDoctor
         
                                 case T_IMPLEMENTS:
                                 // get implements clause
-                                    $interfaceName = $this->_getProgramElementName($tokens, $key);
-                                    $interface =& $rootDoc->classNamed($interfaceName);
-                                    if ($interface) {
-                                        $ce->set('interfaces', $interface);
-                                    }
+                                    $interfaceNames = $this->_getProgramElementName($tokens, $key);
+                                    $ce->set('interfaces', $interfaceNames);
                                     break;
                                     
                                 case T_THROW:

--- a/doclets/debug/debug.php
+++ b/doclets/debug/debug.php
@@ -46,7 +46,7 @@ class Debug extends Doclet
 			echo '- Namespace ', $package->name(), "\n";
 			$this->fieldDoc($package->globals());
 			$this->methodDoc($package->functions());
-			$this->classDoc($package->allClasses());
+			$this->classDoc($package->allClasses(), $rootDoc);
 
 		}
 		
@@ -149,7 +149,7 @@ class Debug extends Doclet
 	 *
 	 * @param ClassDoc[] classes
 	 */
-	function classDoc(&$classes)
+	function classDoc(&$classes, &$rootDoc)
     {
 		$this->depth++;
 		if ($classes) {
@@ -172,8 +172,13 @@ class Debug extends Doclet
 				$interfaces =& $class->interfaces();
 				if ($interfaces) {
 					echo ' implements ';
-					foreach($interfaces as $interface) {
-						echo $interface->packageName(), '\\', $interface->name(), ' ';
+					foreach($interfaces as $interfaceName) {
+            $interface = $rootDoc->classNamed($interfaceName);
+            if ($interface) {
+              echo $interface->packageName(), '\\', $interface->name(), ' ';
+            } else {
+              echo $interfaceName;
+            }
 					}
 				}
 				echo ' [', $class->location(), ']';

--- a/doclets/standard/classWriter.php
+++ b/doclets/standard/classWriter.php
@@ -86,12 +86,17 @@ class ClassWriter extends HTMLWriter
 						echo "<dl>\n";
 						echo "<dt>All Implemented Interfaces:</dt>\n";
 						echo '<dd>';
-						foreach ($implements as $interface) {
-						    echo '<a href="', str_repeat('../', $this->_depth), $interface->asPath(), '">';
-						    if ($interface->packageName() != $class->packageName()) {
-						        echo $interface->packageName(), '\\';
-						    }
-						    echo $interface->name(), '</a> ';
+						foreach ($implements as $interfaceName) {
+                $interface = $rootDoc->classNamed($interfaceName);
+                if ($interface) {
+                    echo '<a href="', str_repeat('../', $this->_depth), $interface->asPath(), '">';
+                    if ($interface->packageName() != $class->packageName()) {
+                        echo $interface->packageName(), '\\';
+                    }
+                    echo $interface->name(), '</a> ';
+                } else {
+                    echo $interfaceName;
+                }
 						}
 						echo "</dd>\n";
 						echo "</dl>\n\n";


### PR DESCRIPTION
...be ommitted from output.

To further illustrate the problem consider the following files parsed in the order listed below:
1. **MyInterface1.php:**
   
    `interface MyInterface1 { ... }`
2. **MyClass.php:**
   
   `class MyClass implements MyInterface1, MyInterface2 { ... }`
3. **MyInterface2.php**
   
   `interface MyInterface2 { ... }`

In the described scenario, the list of implemented interfaces for MyClass will not contain MyInterface1
